### PR TITLE
Declare dependency on Emacs 24

### DIFF
--- a/writeroom-mode.el
+++ b/writeroom-mode.el
@@ -5,6 +5,7 @@
 ;; Author: Joost Kremers <joostkremers@fastmail.fm>
 ;; Maintainer: Joost Kremers <joostkremers@fastmail.fm>
 ;; Created: 11 July 2012
+;; Package-Requires: ((emacs "24"))
 ;; Version: 2.0
 ;; Keywords: text
 


### PR DESCRIPTION
This is needed for lexical-binding, and the code suggests it is only tested on Emacs 24.