### PR TITLE
Add a convenience script I've been using for many years

### DIFF
--- a/jot
+++ b/jot
@@ -16,7 +16,6 @@
 # Bind jot to a desktop keyboard/icon shortcut to make it near-instant
 # TODO: investigate feasibility of "emacsclient -c" plus writeroom-mode
 
-args="--no-splash -fs"
 notebook="$HOME/Desktop/Notebook"
 entry=$(date +%y-%m-%d_%R)
 type="txt"
@@ -24,4 +23,4 @@ mode="text-mode"
 layout="writeroom-mode"
 
 mkdir -p "$notebook"
-emacs "$args" "$notebook"/"$entry"."$type" -f "$mode" -f "$layout"
+emacs --no-splash -fs "$notebook"/"$entry"."$type" -f "$mode" -f "$layout"

--- a/jot
+++ b/jot
@@ -16,6 +16,7 @@
 # Bind jot to a desktop keyboard/icon shortcut to make it near-instant
 # TODO: investigate feasibility of "emacsclient -c" plus writeroom-mode
 
+args="--no-splash -fs"
 notebook="$HOME/Desktop/Notebook"
 entry=$(date +%y-%m-%d_%R)
 type="txt"
@@ -23,4 +24,4 @@ mode="text-mode"
 layout="writeroom-mode"
 
 mkdir -p "$notebook"
-emacs "$notebook"/"$entry"."$type" -f "$mode" -f "$layout"
+emacs "$args" "$notebook"/"$entry"."$type" -f "$mode" -f "$layout"

--- a/jot
+++ b/jot
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Jot down an idea at a moment's notice without thinking about anything else
+# Copyright (C) 2008  Nicholas D Steeves
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# Bind jot to a desktop keyboard/icon shortcut to make it near-instant
+# TODO: investigate feasibility of "emacsclient -c" plus writeroom-mode
+
+notebook="$HOME/Desktop/Notebook"
+entry=$(date +%y-%m-%d_%R)
+type="txt"
+mode="text-mode"
+layout="writeroom-mode"
+
+mkdir -p "$notebook"
+emacs "$notebook"/"$entry"."$type" -f "$mode" -f "$layout"


### PR DESCRIPTION
Hi Joost,

I've been using this for many years, and while trivial, someone else might appreciate it.  It lowers the barrier to entry, because no configuration of ~/.emacs.el is necessary to have a good writeroom experience.  Alternatively, it allows starting emacs with alternative settings to those in ~/.emacs.el, without needing to define a custom function to call.

Limitations:
1. A user still needs to know about C-x C-s or C-x C-c to save his/her work.
2. I haven't looked into if it's possible to make this work with emacsclient
3. There might be a better method of naming/organising files without having to think about a title, but I generally rely on full text search to find something in $notebook.

Please squash my fixup if you merge.

Cheers,
Nicholas