### PR TITLE
Change `:group` of `writeroom-local-effects` to `writeroom`

### DIFF
--- a/writeroom-mode.el
+++ b/writeroom-mode.el
@@ -301,7 +301,7 @@ when `writeroom-mode' is enabled and with the argument \"-1\"
 when it is disabled.  This means that you can add minor-mode
 symbols to this list and have them activated and deactivated
 together with `writeroom-mode'."
-  :group 'writeroom-mode
+  :group 'writeroom
   :type '(repeat function))
 
 (defun turn-on-writeroom-mode ()


### PR DESCRIPTION
This was `writeroom-mode`. I think this was a typo since this group has
not been declared and is also not used by any other custom variable.