### PR TITLE
Revert to default margins

### DIFF
--- a/writeroom-mode.el
+++ b/writeroom-mode.el
@@ -535,7 +535,7 @@ buffer in which it was active."
   ;; margins and fringes must be adjusted.
   (mapc (lambda (w)
           (with-selected-window w
-            (set-window-margins (selected-window) 0 0)
+            (set-window-margins (selected-window) left-margin-width right-margin-width)
             (set-window-fringes (selected-window) nil)))
         (get-buffer-window-list (current-buffer) nil))
 


### PR DESCRIPTION
I made this change to my setup so that on disabling writeroom mode my margins would go back to the defaults I have set and not assume I want them reset to 0.